### PR TITLE
Encode order vars before calculating md5 signature

### DIFF
--- a/includes/class-wc-referralcandy-integration.php
+++ b/includes/class-wc-referralcandy-integration.php
@@ -79,7 +79,7 @@ if (!class_exists('WC_Referralcandy_Integration')) {
                 'data-amount'       => $order->get_total(),
                 'data-currency'     => $order->get_order_currency(),
                 'data-timestamp'    => $timestamp,
-                'data-signature'    => md5($order->billing_email.','.$order->billing_first_name.','.$order->get_total().','.$timestamp.','.$this->get_option('secret_key')),
+                'data-signature'    => md5(urlencode($order->billing_email).','.urlencode($order->billing_first_name).','.$order->get_total().','.$timestamp.','.$this->get_option('secret_key')),
                 'data-external-reference-id' => $order->get_order_number()
             ];
 


### PR DESCRIPTION
Added _urlencode_ functions inside the _md5_ function to fix non-matching signatures.

For more details, you can look at [this](https://github.com/ReferralCandy/woocommerce-referralcandy/issues/9) issue.