### PR TITLE
Fix for issue #15

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ We maintain a list of FAQs on our [help page](http://help.referralcandy.com/)!
 
 == Changelog ==
 
+= 1.3.4 =
+* Fixed deprecation messages for Woocommerce version 3.0 and above
+
 = 1.3.3 =
 * Fixed email encoding issue
 

--- a/woocommerce-referralcandy.php
+++ b/woocommerce-referralcandy.php
@@ -6,7 +6,7 @@
  * Author: ReferralCandy
  * Author URI: http://www.referralcandy.com
  * Text Domain: woocommerce-referralcandy
- * Version: 1.3.3
+ * Version: 1.3.4
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ if (!defined('ABSPATH')) {
     die('Direct access is prohibited.');
 }
 
-if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
+if (preg_grep("/\/woocommerce.php$/", apply_filters('active_plugins', get_option('active_plugins'))) !== null) {
     if (!class_exists('WC_Referralcandy')) {
         class WC_Referralcandy {
             public function __construct() {


### PR DESCRIPTION
This PR is to address [issue #15](https://github.com/ReferralCandy/woocommerce-referralcandy/issues/15) of the plugin. It is for fixing the issue where the plugin continuously generates deprecation message notices.

I added a version check and a few conditions to use the old code for the older versions to have support for older versions of Woocommerce as well. I also placed them in separate variables in case we need to update the other variables in the future as well.

[Clubhouse Ticket](https://app.clubhouse.io/rc/story/11366/updating-rc-woocommerce-plug-in)

Please let me know your thoughts. 🙇 