### PR TITLE
Fix for whitescreen of death

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ We maintain a list of FAQs on our [help page](http://help.referralcandy.com/)!
 
 == Changelog ==
 
+= 1.3.5 =
+* Fixed whitescreen of death issue when the Woocommerce plugin is deactivated while the ReferralCandy plugin is active
+
 = 1.3.4 =
 * Fixed deprecation messages for Woocommerce version 3.0 and above
 

--- a/woocommerce-referralcandy.php
+++ b/woocommerce-referralcandy.php
@@ -6,7 +6,7 @@
  * Author: ReferralCandy
  * Author URI: http://www.referralcandy.com
  * Text Domain: woocommerce-referralcandy
- * Version: 1.3.4
+ * Version: 1.3.5
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,7 +39,7 @@ if (preg_grep("/\/woocommerce.php$/", apply_filters('active_plugins', get_option
 
                     add_filter('woocommerce_integrations', array($this, 'add_integration'));
                 } else {
-                    die('WC_Integration class does not exist.');
+                    add_action('admin_notices', 'missing_prerequisite_notification');
                 }
 
                 load_plugin_textdomain('woocommerce-referralcandy', false, dirname(plugin_basename(__FILE__)) . '/languages/');
@@ -70,6 +70,11 @@ if (preg_grep("/\/woocommerce.php$/", apply_filters('active_plugins', get_option
                 exit;
             }
         }
+    }
+
+    function missing_prerequisite_notification() {
+        $message = 'ReferralCandy <strong>requires</strong> Woocommerce to be installed and activated';
+        printf('<div class="notice notice-error"><p>%1$s</p></div>', $message);
     }
 
     register_activation_hook(__FILE__, 'wc_referralcandy_plugin_activate');


### PR DESCRIPTION
case ref: https://referralcandy.desk.com/agent/case/130603

this PR is to address the issue that wordpress users are unable to access their plugins page once the woocommerce plugin is deactivated and the referralcandy plugin is still active
[screenshot of notif here](http://oi67.tinypic.com/97o9wk.jpg)

repro steps:
1) install and activate woocommerce plugin
2) install and activate referralcandy plugin
3) deactivate woocommerce plugin
4) be stuck in the plugins page with only the error message displayed