### PR TITLE
added option to enable post-purchase popup

### DIFF
--- a/includes/class-wc-referralcandy-integration.php
+++ b/includes/class-wc-referralcandy-integration.php
@@ -49,12 +49,32 @@ if (!class_exists('WC_Referralcandy_Integration')) {
                     'type'              => 'text',
                     'desc_tip'          => false,
                     'default'           => ''
+                ],
+                'popup' => [
+                    'title'             => __('Post-purchase Popup', 'woocommerce-referralcandy'),
+                    'label'             => __('Enable post-purchase Popup', 'woocommerce-referralcandy'),
+                    'type'              => 'checkbox',
+                    'desc_tip'          => false,
+                    'default'           => ''
+                ],
+                'popup_quickfix' => [
+                    'title'             => __('Post-purchase Popup Quickfix', 'woocommerce-referralcandy'),
+                    'label'             => __('Popup is breaking the checkout page?'.'
+                                                Try enabling this option to apply the quickfix!',
+                                                'woocommerce-referralcandy'),
+                    'type'              => 'checkbox',
+                    'desc_tip'          => false,
+                    'default'           => ''
                 ]
             ];
         }
 
         public function sanitize_settings($settings) {
             return $settings;
+        }
+
+        public function is_option_enabled($option_name) {
+            return $this->get_option($option_name) == 'yes'? true : false;
         }
 
         public function woocommerce_order_referralcandy($order_id) {
@@ -75,26 +95,38 @@ if (!class_exists('WC_Referralcandy_Integration')) {
             $billing_first_name = $wc_pre_30? $order->billing_first_name : $order->get_billing_first_name();
             $billing_last_name  = $wc_pre_30? $order->billing_last_name : $order->get_billing_last_name();
             $billing_email      = $wc_pre_30? $order->billing_email : $order->get_billing_email();
+            $encoded_email      = urlencode($billing_email);
             $order_total        = $order->get_total();
             $order_currency     = $wc_pre_30? $order->get_order_currency() : $order->get_currency();
             $order_number       = $order->get_order_number();
 
             $divData = [
-                'id'                => 'refcandy-mint',
+                'id'                => $this->is_option_enabled('popup')? 'refcandy-popsicle' : 'refcandy-mint',
                 'data-app-id'       => $this->get_option('app_id'),
                 'data-fname'        => urlencode($billing_first_name),
                 'data-lname'        => urlencode($billing_last_name),
-                'data-email'        => urlencode($billing_email),
+                'data-email'        => $this->is_option_enabled('popup')? $billing_email : $encoded_email,
                 'data-amount'       => $order_total,
                 'data-currency'     => $order_currency,
                 'data-timestamp'    => $timestamp,
-                'data-signature'    => md5($billing_email.','.$billing_first_name.','.$order_total.','.$timestamp.','.$this->get_option('secret_key')),
-                'data-external-reference-id' => $order_number
+                'data-external-reference-id' => $order_number,
+                'data-signature'    => md5($billing_email.','.$billing_first_name.','.$order_total.','.$timestamp.','.$this->get_option('secret_key'))
             ];
 
+            $popsicle_script = '<script>(function(e){var t,n,r,i,s,o,u,a,f,l,c,h,p,d,v;z="script";l="refcandy-purchase-js";c="refcandy-popsicle";p="go.referralcandy.com/purchase/";t="data-app-id";r={email:"a",fname:"b",lname:"c",amount:"d",currency:"e","accepts-marketing":"f",timestamp:"g","referral-code":"h",locale:"i","external-reference-id":"k",signature:"ab"};i=e.getElementsByTagName(z)[0];s=function(e,t){if(t){return""+e+"="+encodeURIComponent(t)}else{return""}};d=function(e){return""+p+h.getAttribute(t)+".js?lightbox=1&aa=75&"};if(!e.getElementById(l)){h=e.getElementById(c);if(h){o=e.createElement(z);o.id=l;a=function(){var e;e=[];for(n in r){u=r[n];v=h.getAttribute("data-"+n);e.push(s(u,v))}return e}();o.src="//"+d(h.getAttribute(t))+a.join("&");return i.parentNode.insertBefore(o,i)}}})(document);</script>';
+
+            $mint_script = '<script>(function(e){var t,n,r,i,s,o,u,a,f,l,c,h,p,d,v;z="script";l="refcandy-purchase-js";c="refcandy-mint";p="go.referralcandy.com/purchase/";t="data-app-id";r={email:"a",fname:"b",lname:"c",amount:"d",currency:"e","accepts-marketing":"f",timestamp:"g","referral-code":"h",locale:"i","external-reference-id":"k",signature:"ab"};i=e.getElementsByTagName(z)[0];s=function(e,t){if(t){return""+e+"="+t}else{return""}};d=function(e){return""+p+h.getAttribute(t)+".js?aa=75&"};if(!e.getElementById(l)){h=e.getElementById(c);if(h){o=e.createElement(z);o.id=l;a=function(){var e;e=[];for(n in r){u=r[n];v=h.getAttribute("data-"+n);e.push(s(u,v))}return e}();o.src=""+e.location.protocol+"//"+d(h.getAttribute(t))+a.join("&");return i.parentNode.insertBefore(o,i)}}})(document);</script>';
+
+            $quickfix = '';
+            if ($this->is_option_enabled('popup') && $this->is_option_enabled('popup_quickfix')) {
+                $quickfix = '<style>html { position: relative !important; }</style>';
+            }
+
             $div = '<div '.implode(' ', array_map(function ($v, $k) { return $k . '="'.addslashes($v).'"'; }, $divData, array_keys($divData))).'></div>';
-            $script = '<script>(function(e){var t,n,r,i,s,o,u,a,f,l,c,h,p,d,v;z="script";l="refcandy-purchase-js";c="refcandy-mint";p="go.referralcandy.com/purchase/";t="data-app-id";r={email:"a",fname:"b",lname:"c",amount:"d",currency:"e","accepts-marketing":"f",timestamp:"g","referral-code":"h",locale:"i","external-reference-id":"k",signature:"ab"};i=e.getElementsByTagName(z)[0];s=function(e,t){if(t){return""+e+"="+t}else{return""}};d=function(e){return""+p+h.getAttribute(t)+".js?aa=75&"};if(!e.getElementById(l)){h=e.getElementById(c);if(h){o=e.createElement(z);o.id=l;a=function(){var e;e=[];for(n in r){u=r[n];v=h.getAttribute("data-"+n);e.push(s(u,v))}return e}();o.src=""+e.location.protocol+"//"+d(h.getAttribute(t))+a.join("&");return i.parentNode.insertBefore(o,i)}}})(document);</script>';
-            echo $div.$script;
+
+            $script = $this->is_option_enabled('popup')? $popsicle_script : $mint_script;
+
+            echo $div.$script.$quickfix;
         }
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ We maintain a list of FAQs on our [help page](http://help.referralcandy.com/)!
 
 == Changelog ==
 
+= 1.3.6 =
+* Added an option to enable the post-purchase popup widget on the checkout completed / thank you page =
+
 = 1.3.5 =
 * Fixed whitescreen of death issue when the Woocommerce plugin is deactivated while the ReferralCandy plugin is active
 

--- a/woocommerce-referralcandy.php
+++ b/woocommerce-referralcandy.php
@@ -6,7 +6,7 @@
  * Author: ReferralCandy
  * Author URI: http://www.referralcandy.com
  * Text Domain: woocommerce-referralcandy
- * Version: 1.3.5
+ * Version: 1.3.6
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Hey guys,

Since there have been a number of cases with retailers asking about how to implement the post-purchases popup widget, I decided to just add the option to their settings page.

There are two options actually:
1) Enable the post-purchase popup
2) Enable the quickfix for the post-purchase popup

**_What is the quickfix for?_**
Our post-purchase popup widget(PPPW), is currently setting the `HTML` tag's position to `fixed`. To resolve this issue without having to break our current widget's setup, I experimented a bit on this and found out that adding a `<style>html { position: relative !important; }</style>` was an effective enough fix for this.
Here is what it looks like on the settings page.
<a href="http://tinypic.com?ref=2h88mwz" target="_blank"><img src="http://i68.tinypic.com/2h88mwz.jpg" border="0" alt="Image and video hosting by TinyPic"></a>

Let me know what you guys think!