### PR TITLE
fixed issue where spaces in names produce checksum errors

### DIFF
--- a/includes/class-wc-referralcandy-integration.php
+++ b/includes/class-wc-referralcandy-integration.php
@@ -100,6 +100,13 @@ if (!class_exists('WC_Referralcandy_Integration')) {
             $order_currency     = $wc_pre_30? $order->get_order_currency() : $order->get_currency();
             $order_number       = $order->get_order_number();
 
+            // make sure first name is always populated to avoid checksum errors
+            if (empty(strip_tags($billing_first_name)) === true) { // if first name is empty
+                // extract name from email (i.e. john from john+doe@domain.com or john_doe from john_doe@domain.com)
+                preg_match('/(?<extracted_name>\w+)/', $billing_email, $matches);
+                $billing_first_name = $matches['extracted_name']; // assign extracted name as first name
+            }
+
             $divData = [
                 'id'                => $this->is_option_enabled('popup')? 'refcandy-popsicle' : 'refcandy-mint',
                 'data-app-id'       => $this->get_option('app_id'),

--- a/includes/class-wc-referralcandy-integration.php
+++ b/includes/class-wc-referralcandy-integration.php
@@ -103,8 +103,8 @@ if (!class_exists('WC_Referralcandy_Integration')) {
             $divData = [
                 'id'                => $this->is_option_enabled('popup')? 'refcandy-popsicle' : 'refcandy-mint',
                 'data-app-id'       => $this->get_option('app_id'),
-                'data-fname'        => urlencode($billing_first_name),
-                'data-lname'        => urlencode($billing_last_name),
+                'data-fname'        => $billing_first_name,
+                'data-lname'        => $billing_last_name,
                 'data-email'        => $this->is_option_enabled('popup')? $billing_email : $encoded_email,
                 'data-amount'       => $order_total,
                 'data-currency'     => $order_currency,

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ We maintain a list of FAQs on our [help page](http://help.referralcandy.com/)!
 == Changelog ==
 
 = 1.3.7 =
-* Fixed issue where an order with spaces in the names produce checksum errors
+* Fixed issue where orders with spaces in the names or have no name at all produce checksum errors
 
 = 1.3.6 =
 * Added an option to enable the post-purchase popup widget on the checkout completed / thank you page

--- a/readme.txt
+++ b/readme.txt
@@ -70,8 +70,11 @@ We maintain a list of FAQs on our [help page](http://help.referralcandy.com/)!
 
 == Changelog ==
 
+= 1.3.7 =
+* Fixed issue where an order with spaces in the names produce checksum errors
+
 = 1.3.6 =
-* Added an option to enable the post-purchase popup widget on the checkout completed / thank you page =
+* Added an option to enable the post-purchase popup widget on the checkout completed / thank you page
 
 = 1.3.5 =
 * Fixed whitescreen of death issue when the Woocommerce plugin is deactivated while the ReferralCandy plugin is active

--- a/woocommerce-referralcandy.php
+++ b/woocommerce-referralcandy.php
@@ -6,7 +6,7 @@
  * Author: ReferralCandy
  * Author URI: http://www.referralcandy.com
  * Text Domain: woocommerce-referralcandy
- * Version: 1.3.6
+ * Version: 1.3.7
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
this PR is to address an issue where if a customer inputs a name with a space/spaces, the encoding would only cause the order to produce checksum errors. i removed the `urlencode` for both names and tested purchases with the post-purchase widget both `ON` and `OFF`, it doesn't seem to have any effect other than getting rid of the checksum errors.