### PR TITLE
move woocommerce to API integration

### DIFF
--- a/includes/class-rc-order.php
+++ b/includes/class-rc-order.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * WooCommerce ReferralCandy Integration.
+ *
+ * @package  RC_Order
+ * @category Integration
+ * @author   ReferralCandy
+ */
+
+class RC_Order {
+    public $wc_pre_30 = false;
+    public $api_id;
+    public $secret_key;
+    public $first_name;
+    public $last_name;
+    public $email;
+    public $discount_code;
+    public $total;
+    public $currency;
+    public $order_number;
+    public $order_timestamp;
+    public $browser_ip;
+    public $user_agent;
+    public $referrer_id;
+
+    public function __construct($wc_order_id) {
+        $wc_order   = new WC_Order($wc_order_id);
+        $order_data = $wc_order->get_data();
+
+        $this->wc_pre_30        = version_compare(WC_VERSION, '3.0.0', '<');
+        $this->first_name       = $order_data['billing']['first_name'];
+        $this->last_name        = $order_data['billing']['last_name'];
+        $this->email            = $order_data['billing']['email'];
+        $this->total            = $order_data['total'];
+        $this->currency         = $order_data['currency'];
+        $this->order_number     = $order_data['id'];
+        $this->order_timestamp  = $order_data['date_created']->getTimestamp();
+
+        foreach($wc_order->get_meta_data() as $i => $meta_data) {
+            $data = $meta_data->get_data();
+
+            switch($data['key']) {
+                case 'api_id':
+                    $this->api_id = $data['value'];
+                    break;
+
+                case 'secret_key':
+                    $this->secret_key = $data['value'];
+                    break;
+
+                case 'browser_ip':
+                    $this->browser_ip = $data['value'];
+                    break;
+
+                case 'user_agent':
+                    $this->user_agent = $data['value'];
+                    break;
+
+                case 'referrer_id':
+                    $this->referrer_id = $data['value'];
+                    break;
+            }
+        }
+    }
+
+    private function generate_post_fields($specific_keys = [], $additional_keys = []) {
+        $post_fields = [
+            'accessID'              => $this->api_id,
+            'first_name'            => $this->first_name,
+            'last_name'             => $this->last_name,
+            'email'                 => $this->email,
+            'order_timestamp'       => $this->order_timestamp,
+            'browser_ip'            => $this->browser_ip,
+            'user_agent'            => $this->user_agent,
+            'invoice_amount'        => $this->total,
+            'currency_code'         => $this->currency,
+            'external_reference_id' => $this->order_number,
+            'timestamp'             => time(),
+        ];
+
+        // only add referrer_id if present
+        if ($this->referrer_id != null) {
+            $post_fields['referrer_id'] = $this->referrer_id;
+        }
+
+        // check if we need only specific post fields from the default
+        if ($specific_keys != null && count($specific_keys) > 0) {
+            $new_post_fields = [];
+            foreach($post_fields as $field => $value) {
+                if (in_array($field, $specific_keys)) {
+                    $new_post_fields[$field] = $value;
+                }
+            }
+
+            // only overwrite post fields if at least one key is retreived
+            if ($new_post_fields != null && count($new_post_fields) > 0) {
+                $post_fields = $new_post_fields;
+            }
+        }
+
+        // check if there are additional keys we want to add to the payload
+        if ($additional_keys != null && count($additional_keys) > 0) {
+            $post_fields = array_merge($post_fields, $additional_keys);
+        }
+
+        // sort keys
+        ksort($post_fields);
+
+        return $post_fields;
+    }
+
+    // created this function because PHP's http_build_query function converts 'timestamp' to 'xstamp'
+    private function prepParams(Array $params) {
+        $preppedParams = '';
+        foreach($params as $key => $value) {
+            $preppedParams .= "$key=$value";
+        }
+
+        return $preppedParams;
+    }
+
+    private function generate_request_body($post_fields) {
+        if (!empty($this->secret_key) && !empty($this->api_id)) {
+            $params = [
+                'body' => $post_fields
+            ];
+            $params['body']['signature'] = md5($this->secret_key . $this->prepParams($post_fields));
+
+            return $params;
+        }
+    }
+
+    // https://www.referralcandy.com/api#purchase
+    public function submit_purchase() {
+        $endpoint = 'https://my.referralcandy.com/api/v1/purchase.json';
+
+        if (!empty($this->secret_key) && !empty($this->api_id)) {
+            $response = wp_safe_remote_post(
+                $endpoint,
+                $this->generate_request_body($this->generate_post_fields())
+            );
+        }
+    }
+
+    // https://www.referralcandy.com/api#referral
+    public function process_return() {
+        $endpoint = 'https://my.referralcandy.com/api/v1/referral.json';
+
+        if (!empty($this->secret_key) && !empty($this->api_id)) {
+            $specific_keys = [
+                'accessID',
+                'timestamp',
+            ];
+
+            $additional_keys = [
+                'customer_email'    => $this->email,
+                'returned'          => 'true',
+            ];
+
+            $response = wp_safe_remote_post(
+                $endpoint,
+                $this->generate_request_body($this->generate_post_fields($specific_keys, $additional_keys))
+            );
+        }
+    }
+}

--- a/includes/class-rc-order.php
+++ b/includes/class-rc-order.php
@@ -141,26 +141,4 @@ class RC_Order {
             );
         }
     }
-
-    // https://www.referralcandy.com/api#referral
-    public function process_return() {
-        $endpoint = 'https://my.referralcandy.com/api/v1/referral.json';
-
-        if (!empty($this->secret_key) && !empty($this->api_id)) {
-            $specific_keys = [
-                'accessID',
-                'timestamp',
-            ];
-
-            $additional_keys = [
-                'customer_email'    => $this->email,
-                'returned'          => 'true',
-            ];
-
-            $response = wp_safe_remote_post(
-                $endpoint,
-                $this->generate_request_body($this->generate_post_fields($specific_keys, $additional_keys))
-            );
-        }
-    }
 }

--- a/includes/class-wc-referralcandy-integration.php
+++ b/includes/class-wc-referralcandy-integration.php
@@ -58,7 +58,7 @@ if (!class_exists('WC_Referralcandy_Integration')) {
                 'secret_key' => [
                     'title'             => __('Secret key', 'woocommerce-referralcandy'),
                     'type'              => 'text',
-                    'desc'              => __('You can find your API Secrey Key on https://my.referralcandy.com/settings'),
+                    'desc'              => __('You can find your API Secret Key on https://my.referralcandy.com/settings'),
                     'desc_tip'          => true,
                     'default'           => ''
                 ],

--- a/includes/class-wc-referralcandy-integration.php
+++ b/includes/class-wc-referralcandy-integration.php
@@ -34,8 +34,6 @@ if (!class_exists('WC_Referralcandy_Integration')) {
             add_action('save_post',                                             [$this, 'add_referralcandy_data']);
             add_action('woocommerce_thankyou',                                  [$this, 'render_post_purchase_popup']);
             add_action('woocommerce_order_status_completed',                    [$this, 'rc_submit_purchase'], 10, 1);
-            add_action('woocommerce_order_status_cancelled',                    [$this, 'rc_process_return'], 10, 1);
-            add_action('woocommerce_order_refunded',                            [$this, 'rc_process_return'], 10, 1);
 
             // Filters.
             add_filter('woocommerce_settings_api_sanitized_fields_' . $this->id, array($this, 'sanitize_settings'));
@@ -117,11 +115,6 @@ if (!class_exists('WC_Referralcandy_Integration')) {
         public function rc_submit_purchase($order_id) {
             $rc_order = new RC_Order($order_id);
             $rc_order->submit_purchase();
-        }
-
-        public function rc_process_return($order_id) {
-            $rc_order = new RC_Order($order_id);
-            $rc_order->process_return();
         }
 
         public function render_post_purchase_popup($order_id) {

--- a/includes/class-wc-referralcandy-integration.php
+++ b/includes/class-wc-referralcandy-integration.php
@@ -22,15 +22,20 @@ if (!class_exists('WC_Referralcandy_Integration')) {
 
             // Load the settings.
             $this->init_form_fields();
-            $this->init_settings();
 
             // Define user set variables.
+            $this->api_id              = $this->get_option('api_id');
             $this->app_id              = $this->get_option('app_id');
             $this->secret_key          = $this->get_option('secret_key');
 
             // Actions.
-            add_action('woocommerce_update_options_integration_' . $this->id, array($this, 'process_admin_options'));
-            add_action('woocommerce_thankyou', array($this, 'woocommerce_order_referralcandy'));
+            add_action('woocommerce_update_options_integration_' . $this->id,   [$this, 'process_admin_options']);
+            add_action('init',                                                  [$this, 'rc_set_referrer_cookie']);
+            add_action('save_post',                                             [$this, 'add_referralcandy_data']);
+            add_action('woocommerce_thankyou',                                  [$this, 'render_post_purchase_popup']);
+            add_action('woocommerce_order_status_completed',                    [$this, 'rc_submit_purchase'], 10, 1);
+            add_action('woocommerce_order_status_cancelled',                    [$this, 'rc_process_return'], 10, 1);
+            add_action('woocommerce_order_refunded',                            [$this, 'rc_process_return'], 10, 1);
 
             // Filters.
             add_filter('woocommerce_settings_api_sanitized_fields_' . $this->id, array($this, 'sanitize_settings'));
@@ -38,16 +43,25 @@ if (!class_exists('WC_Referralcandy_Integration')) {
 
         public function init_form_fields() {
             $this->form_fields = [
+                'api_id' => [
+                    'title'             => __('API Access ID', 'woocommerce-referralcandy'),
+                    'type'              => 'text',
+                    'desc'              => __('You can find your API Access ID on https://my.referralcandy.com/settings'),
+                    'desc_tip'          => true,
+                    'default'           => ''
+                ],
                 'app_id' => [
                     'title'             => __('App ID', 'woocommerce-referralcandy'),
                     'type'              => 'text',
-                    'desc_tip'          => false,
+                    'desc'              => __('You can find your App ID on https://my.referralcandy.com/settings'),
+                    'desc_tip'          => true,
                     'default'           => ''
                 ],
                 'secret_key' => [
                     'title'             => __('Secret key', 'woocommerce-referralcandy'),
                     'type'              => 'text',
-                    'desc_tip'          => false,
+                    'desc'              => __('You can find your API Secrey Key on https://my.referralcandy.com/settings'),
+                    'desc_tip'          => true,
                     'default'           => ''
                 ],
                 'popup' => [
@@ -73,67 +87,73 @@ if (!class_exists('WC_Referralcandy_Integration')) {
             return $settings;
         }
 
-        public function is_option_enabled($option_name) {
+        private function is_option_enabled($option_name) {
             return $this->get_option($option_name) == 'yes'? true : false;
         }
 
-        public function woocommerce_order_referralcandy($order_id) {
-            $wc_pre_30 = version_compare( WC_VERSION, '3.0.0', '<');
+        public function add_referralcandy_data($post_id) {
+            try {
+                if (get_post($post_id)->post_type == 'shop_order') {
+                    $wc_order = new WC_Order($post_id);
 
-            $order = new WC_Order($order_id);
+                    // save meta datas for later use
+                    $wc_order->update_meta_data('api_id',       $this->api_id);
+                    $wc_order->update_meta_data('secret_key',   $this->secret_key);
+                    $wc_order->update_meta_data('browser_ip',   $_SERVER['REMOTE_ADDR']);
+                    $wc_order->update_meta_data('user_agent',   $_SERVER['HTTP_USER_AGENT']);
 
-            // https://en.support.wordpress.com/settings/general-settings/2/#timezone
-            // This option is set when a timezone name is selected
-            $timezone_string = get_option('timezone_string');
+                    // prevent admin cookies from automatically adding a referrer_id; this can be done manually though
+                    if (is_admin() == false) {
+                        $wc_order->update_meta_data('referrer_id',  $_COOKIE['rc_referrer_id']);
+                    }
 
-            if (!empty($timezone_string)) {
-                $timestamp = DateTime::createFromFormat('Y-m-d H:i:s', $order->order_date, new DateTimeZone($timezone_string))->getTimestamp();
-            } else {
-                $timestamp = time();
+                    $wc_order->save();
+                }
+            } catch(Exception $e) {
+
             }
+        }
 
-            $billing_first_name = $wc_pre_30? $order->billing_first_name : $order->get_billing_first_name();
-            $billing_last_name  = $wc_pre_30? $order->billing_last_name : $order->get_billing_last_name();
-            $billing_email      = $wc_pre_30? $order->billing_email : $order->get_billing_email();
-            $encoded_email      = urlencode($billing_email);
-            $order_total        = $order->get_total();
-            $order_currency     = $wc_pre_30? $order->get_order_currency() : $order->get_currency();
-            $order_number       = $order->get_order_number();
+        public function rc_submit_purchase($order_id) {
+            $rc_order = new RC_Order($order_id);
+            $rc_order->submit_purchase();
+        }
 
-            // make sure first name is always populated to avoid checksum errors
-            if (empty(strip_tags($billing_first_name)) === true) { // if first name is empty
-                // extract name from email (i.e. john from john+doe@domain.com or john_doe from john_doe@domain.com)
-                preg_match('/(?<extracted_name>\w+)/', $billing_email, $matches);
-                $billing_first_name = $matches['extracted_name']; // assign extracted name as first name
-            }
+        public function rc_process_return($order_id) {
+            $rc_order = new RC_Order($order_id);
+            $rc_order->process_return();
+        }
 
-            $divData = [
-                'id'                => $this->is_option_enabled('popup')? 'refcandy-popsicle' : 'refcandy-mint',
-                'data-app-id'       => $this->get_option('app_id'),
-                'data-fname'        => $billing_first_name,
-                'data-lname'        => $billing_last_name,
-                'data-email'        => $this->is_option_enabled('popup')? $billing_email : $encoded_email,
-                'data-amount'       => $order_total,
-                'data-currency'     => $order_currency,
-                'data-timestamp'    => $timestamp,
-                'data-external-reference-id' => $order_number,
-                'data-signature'    => md5($billing_email.','.$billing_first_name.','.$order_total.','.$timestamp.','.$this->get_option('secret_key'))
-            ];
+        public function render_post_purchase_popup($order_id) {
+            $rc_order = new RC_Order($order_id);
 
-            $popsicle_script = '<script>(function(e){var t,n,r,i,s,o,u,a,f,l,c,h,p,d,v;z="script";l="refcandy-purchase-js";c="refcandy-popsicle";p="go.referralcandy.com/purchase/";t="data-app-id";r={email:"a",fname:"b",lname:"c",amount:"d",currency:"e","accepts-marketing":"f",timestamp:"g","referral-code":"h",locale:"i","external-reference-id":"k",signature:"ab"};i=e.getElementsByTagName(z)[0];s=function(e,t){if(t){return""+e+"="+encodeURIComponent(t)}else{return""}};d=function(e){return""+p+h.getAttribute(t)+".js?lightbox=1&aa=75&"};if(!e.getElementById(l)){h=e.getElementById(c);if(h){o=e.createElement(z);o.id=l;a=function(){var e;e=[];for(n in r){u=r[n];v=h.getAttribute("data-"+n);e.push(s(u,v))}return e}();o.src="//"+d(h.getAttribute(t))+a.join("&");return i.parentNode.insertBefore(o,i)}}})(document);</script>';
+            $div = "<div
+                      id='refcandy-lollipop'
+                      data-id='$rc_order->api_id'
+                      data-fname='$rc_order->first_name'
+                      data-lname='$rc_order->last_name'
+                      data-email='$rc_order->email'
+                      data-accepts-marketing='true'
+                    ></div>";
 
-            $mint_script = '<script>(function(e){var t,n,r,i,s,o,u,a,f,l,c,h,p,d,v;z="script";l="refcandy-purchase-js";c="refcandy-mint";p="go.referralcandy.com/purchase/";t="data-app-id";r={email:"a",fname:"b",lname:"c",amount:"d",currency:"e","accepts-marketing":"f",timestamp:"g","referral-code":"h",locale:"i","external-reference-id":"k",signature:"ab"};i=e.getElementsByTagName(z)[0];s=function(e,t){if(t){return""+e+"="+t}else{return""}};d=function(e){return""+p+h.getAttribute(t)+".js?aa=75&"};if(!e.getElementById(l)){h=e.getElementById(c);if(h){o=e.createElement(z);o.id=l;a=function(){var e;e=[];for(n in r){u=r[n];v=h.getAttribute("data-"+n);e.push(s(u,v))}return e}();o.src=""+e.location.protocol+"//"+d(h.getAttribute(t))+a.join("&");return i.parentNode.insertBefore(o,i)}}})(document);</script>';
+            $popup_script = '<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.defer=true;js.src="//portal.referralcandy.com/assets/widgets/refcandy-lollipop.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","refcandy-lollipop-js");</script>';
 
             $quickfix = '';
             if ($this->is_option_enabled('popup') && $this->is_option_enabled('popup_quickfix')) {
                 $quickfix = '<style>html { position: relative !important; }</style>';
             }
 
-            $div = '<div '.implode(' ', array_map(function ($v, $k) { return $k . '="'.addslashes($v).'"'; }, $divData, array_keys($divData))).'></div>';
+            if ($this->is_option_enabled('popup') == true) {
+                echo $div.$popup_script.$quickfix;
+            }
+        }
 
-            $script = $this->is_option_enabled('popup')? $popsicle_script : $mint_script;
+        public function rc_set_referrer_cookie() {
+            $days_to_keep_cookies = 28;
 
-            echo $div.$script.$quickfix;
+            if (isset($_GET['aic']) && $_GET['aic'] !== null) {
+                setcookie('rc_referrer_id', $_GET['aic'], time() + (86400 * $days_to_keep_cookies), "/");
+            }
         }
     }
 }

--- a/includes/class-wc-referralcandy-integration.php
+++ b/includes/class-wc-referralcandy-integration.php
@@ -133,7 +133,7 @@ if (!class_exists('WC_Referralcandy_Integration')) {
                       data-fname='$rc_order->first_name'
                       data-lname='$rc_order->last_name'
                       data-email='$rc_order->email'
-                      data-accepts-marketing='true'
+                      data-accepts-marketing='false'
                     ></div>";
 
             $popup_script = '<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.defer=true;js.src="//portal.referralcandy.com/assets/widgets/refcandy-lollipop.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","refcandy-lollipop-js");</script>';

--- a/readme.txt
+++ b/readme.txt
@@ -70,7 +70,8 @@ We maintain a list of FAQs on our [help page](http://help.referralcandy.com/)!
 
 == Changelog ==
 
-= 1.4.0 =
+= 2.0.0 =
+* Plugin now uses the API integration of ReferralCandy
 * Orders created from the Woocommerce dashboard are now registered in the ReferralCandy dashboard
 * Referrals for cancelled / refunded orders are now removed as well from the ReferralCandy dashboard
 

--- a/readme.txt
+++ b/readme.txt
@@ -73,7 +73,6 @@ We maintain a list of FAQs on our [help page](http://help.referralcandy.com/)!
 = 2.0.0 =
 * Plugin now uses the API integration of ReferralCandy
 * Orders created from the Woocommerce dashboard are now registered in the ReferralCandy dashboard
-* Referrals for cancelled / refunded orders are now removed as well from the ReferralCandy dashboard
 
 = 1.3.7 =
 * Fixed issue where orders with spaces in the names or have no name at all produce checksum errors

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: referralcandy
 Tags: referral program, customer referral program, refer-a-friend, tell-a-friend, marketing, customer acquisition, word-of-mouth, marketing app, viral marketing, social marketing, marketing, woocommerce
 Requires at least: 3.0
-Tested up to: 4.7.3
+Tested up to: 4.9.8
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -59,6 +59,8 @@ Learn about the details on our [How ReferralCandy Works](http://www.referralcand
 2. Fill-out your App ID and Secret Key. You can get them from [ReferralCandy Admin Settings > Plugin tokens](https://my.referralcandy.com/settings))
 3. Click on **Save changes** and it's done!
 
+**Please make sure that the plugin can make outbound requests for the API calls
+
 
 == Frequently Asked Questions ==
 
@@ -72,6 +74,7 @@ We maintain a list of FAQs on our [help page](http://help.referralcandy.com/)!
 
 = 2.0.0 =
 * Plugin now uses the API integration of ReferralCandy
+* Only orders marked as completed are submitted to ReferralCandy
 * Orders created from the Woocommerce dashboard are now registered in the ReferralCandy dashboard
 
 = 1.3.7 =

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,10 @@ We maintain a list of FAQs on our [help page](http://help.referralcandy.com/)!
 
 == Changelog ==
 
+= 1.4.0 =
+* Orders created from the Woocommerce dashboard are now registered in the ReferralCandy dashboard
+* Referrals for cancelled / refunded orders are now removed as well from the ReferralCandy dashboard
+
 = 1.3.7 =
 * Fixed issue where orders with spaces in the names or have no name at all produce checksum errors
 

--- a/woocommerce-referralcandy.php
+++ b/woocommerce-referralcandy.php
@@ -6,7 +6,7 @@
  * Author: ReferralCandy
  * Author URI: http://www.referralcandy.com
  * Text Domain: woocommerce-referralcandy
- * Version: 1.3.7
+ * Version: 1.4.0
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,9 +35,8 @@ if (preg_grep("/\/woocommerce.php$/", apply_filters('active_plugins', get_option
 
             public function init() {
                 if (class_exists('WC_Integration')) {
-                    include_once 'includes/class-wc-referralcandy-integration.php';
-
-                    add_filter('woocommerce_integrations', array($this, 'add_integration'));
+                    add_action('woocommerce_integrations', 'autoload_classes');
+                    add_filter('woocommerce_integrations', [$this, 'add_integration']);
                 } else {
                     add_action('admin_notices', 'missing_prerequisite_notification');
                 }
@@ -53,6 +52,16 @@ if (preg_grep("/\/woocommerce.php$/", apply_filters('active_plugins', get_option
         }
 
         $WC_Referralcandy = new WC_Referralcandy(__FILE__);
+    }
+
+    function autoload_classes() {
+        $files = scandir(dirname(__FILE__) . '/includes');
+        $valid_extensions = ['php'];
+        foreach ($files as $index => $file) {
+            if (in_array(pathinfo($file)['extension'], $valid_extensions)) {
+                require_once('includes/' . pathinfo($file)['basename']);
+            }
+        }
     }
 
     function wc_referralcandy_plugin_activate() {

--- a/woocommerce-referralcandy.php
+++ b/woocommerce-referralcandy.php
@@ -6,7 +6,7 @@
  * Author: ReferralCandy
  * Author URI: http://www.referralcandy.com
  * Text Domain: woocommerce-referralcandy
- * Version: 1.4.0
+ * Version: 2.0.0
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
this PR attempts to solve the following issue:
* purchases that are not marked as completed are registered on the dashboard -- causes issues when the purchaser cancels but the referral is still marked as valid which prompts the user to manually check everything
* other plugins that have broken javascript tags / have javascript errors prevent our own javascript code from firing
* retailers with redirects upon checkout causes our javascript code to not be rendered

how it works:
- you click on a referral link and get redirected to the retailer's store
- a cookie is created which stores the `aic`, which is then added to the order's meta data / custom fields
- you as a customer, make a purchase
- woocommerce turns your purchase into a `WC_Order`, the plugin then adds metadatas for our use which consist of the ff: api_id, secret_key, browser_ip, user_agent, referrer_id(from session)
- once the order is marked as completed from the admin's panel, the `RC_Order` will be triggered to submit the purchase via API

other features:
`referrals` can now be assigned upon order creation on dashboard by adding a custom field called `referrer_id` from the dropdown
![screen shot 2018-10-04 at 12 33 24 pm](https://user-images.githubusercontent.com/29734765/46453034-cb6fe380-c7d1-11e8-821f-f59d8bdaa016.png)

`cancelled / refunded orders` remove referrals from the dashboard as well
![screen shot 2018-10-04 at 12 35 40 pm](https://user-images.githubusercontent.com/29734765/46453076-083bda80-c7d2-11e8-9a7b-106b2fe45377.png)

`creation of orders via woocommerce dashboard` is now enabled, thanks to @clark-pan 's eagle-eyeszz. i also disabled automatic adding of the `aic` / `referrer_id` when the order is created by an *admin*

`post-purchase popup rendering` is now separate from creation of orders. it is the only piece of code running on the `thank you page`, order creation is now on a hook when saving posts of type `shop_order`