### PR TITLE
fixed bug for woocommerce integration tab

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,9 @@ We maintain a list of FAQs on our [help page](http://help.referralcandy.com/)!
 
 == Changelog ==
 
+= 2.0.1 =
+* Fixed bug where the plugin breaks the Woocommerce Integration tab
+
 = 2.0.0 =
 * Plugin now uses the API integration of ReferralCandy
 * Only orders marked as completed are submitted to ReferralCandy

--- a/woocommerce-referralcandy.php
+++ b/woocommerce-referralcandy.php
@@ -6,7 +6,7 @@
  * Author: ReferralCandy
  * Author URI: http://www.referralcandy.com
  * Text Domain: woocommerce-referralcandy
- * Version: 2.0.0
+ * Version: 2.0.1
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,7 +35,7 @@ if (preg_grep("/\/woocommerce.php$/", apply_filters('active_plugins', get_option
 
             public function init() {
                 if (class_exists('WC_Integration')) {
-                    add_action('woocommerce_integrations', 'autoload_classes');
+                    autoload_classes();
                     add_filter('woocommerce_integrations', [$this, 'add_integration']);
                 } else {
                     add_action('admin_notices', 'missing_prerequisite_notification');


### PR DESCRIPTION
there was an issue with the autoloading of classes which broke the integration page(page only, not the functions) which rendered other integrations to be inaccessible via Woocommerce's integration page