### PR TITLE
Fixed checkout tracking code issue

### DIFF
--- a/includes/class-rc-order.php
+++ b/includes/class-rc-order.php
@@ -139,8 +139,8 @@ class RC_Order {
             $response   = wp_safe_remote_post($endpoint, $params);
 
             # only used to cross reference requests
-            error_log('ReferralCandy API#purchase params: ' . print_r($params['body'], true));
-            error_log('ReferralCandy API#purchase response: ' . print_r(json_decode($response['body']), true));
+            // error_log('ReferralCandy API#purchase params: ' . print_r($params['body'], true));
+            // error_log('ReferralCandy API#purchase response: ' . print_r(json_decode($response['body']), true));
         }
     }
 }

--- a/includes/class-wc-referralcandy-integration.php
+++ b/includes/class-wc-referralcandy-integration.php
@@ -34,8 +34,8 @@ if (!class_exists('WC_Referralcandy_Integration')) {
             add_action('woocommerce_update_options_integration_' . $this->id,   [$this, 'process_admin_options']);
             add_action('admin_notices',                                         [$this, 'check_plugin_requirements']);
             add_action('init',                                                  [$this, 'rc_set_referrer_cookie']);
+            add_action('wp_enqueue_scripts',                                    [$this, 'render_tracking_code']);
             add_action('save_post',                                             [$this, 'add_referrer_id']);
-            add_action('template_redirect',                                     [$this, 'render_tracking_code']);
             add_action('woocommerce_thankyou',                                  [$this, 'render_post_purchase_popup']);
             add_action('woocommerce_order_status_' . $this->status_to,          [$this, 'rc_submit_purchase'], 10, 1);
 
@@ -165,7 +165,7 @@ if (!class_exists('WC_Referralcandy_Integration')) {
             $rc_order->submit_purchase();
         }
 
-        public function render_tracking_code($post) {
+        public function render_tracking_code() {
             if (is_page($this->tracking_page) == true) {
                 $tracking_code = '<script type="text/javascript"> !function(d,s) { var rc = "//go.referralcandy.com/purchase/'. $this->app_id .'.js"; var js = d.createElement(s); js.src = rc; var fjs = d.getElementsByTagName(s)[0]; fjs.parentNode.insertBefore(js,fjs); }(document,"script"); </script>';
                 echo $tracking_code;

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,9 @@ We maintain a list of FAQs on our [help page](http://answers.referralcandy.com/)
 
 == Changelog ==
 
+= 2.2.4 =
+* Fixed issue where there the tracking code is rendered before the html
+
 = 2.2.3 =
 * Fixed issue where the plugin uses the `rc_referrer_id` cookie even if non-existent
 

--- a/woocommerce-referralcandy.php
+++ b/woocommerce-referralcandy.php
@@ -6,7 +6,7 @@
  * Author: ReferralCandy
  * Author URI: http://www.referralcandy.com
  * Text Domain: woocommerce-referralcandy
- * Version: 2.2.3
+ * Version: 2.2.4
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
* Fixed issue where there the tracking code is rendered before the html

The issue created a huge space / gap on the checkout pages of some themes, this PR fixes that issue while still rendering the tracking code properly