### PR TITLE
Fix customer locale upon purchase

### DIFF
--- a/includes/class-rc-order.php
+++ b/includes/class-rc-order.php
@@ -16,6 +16,7 @@ class RC_Order {
     public $first_name;
     public $last_name;
     public $email;
+    public $locale;
     public $discount_code;
     public $total;
     public $currency;
@@ -46,7 +47,8 @@ class RC_Order {
             $this->browser_ip        = $this->order->customer_ip_address;
             $this->user_agent        = $this->order->customer_user_agent;
             $this->accepts_marketing = get_post_meta($wc_order_id, 'rc_accepts_marketing', true) ? 'true' : 'false';
-            $this->referrer_id       = get_post_meta($wc_order_id, 'rc_referrer_id', true);
+            $this->referrer_id       = get_post_meta($wc_order_id, 'rc_aic', true);
+            $this->locale            = get_post_meta($wc_order_id, 'rc_loc', true);
         } else {
             $order_data = $this->order->get_data();
 
@@ -60,7 +62,8 @@ class RC_Order {
             $this->browser_ip        = $order_data['customer_ip_address'];
             $this->user_agent        = $order_data['customer_user_agent'];
             $this->accepts_marketing = $this->order->get_meta('rc_accepts_marketing', true, 'view') ? 'true' : 'false';
-            $this->referrer_id       = $this->order->get_meta('rc_referrer_id', true, 'view');
+            $this->referrer_id       = $this->order->get_meta('rc_aic', true, 'view');
+            $this->locale            = $this->order->get_meta('rc_loc', true, 'view');
         }
 
         $this->api_id           = $integration->api_id;
@@ -74,6 +77,7 @@ class RC_Order {
             'first_name'            => $this->first_name,
             'last_name'             => $this->last_name,
             'email'                 => $this->email,
+            'locale'                => $this->locale,
             'order_timestamp'       => $this->order_timestamp,
             'browser_ip'            => $this->browser_ip,
             'user_agent'            => $this->user_agent,

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,11 @@ We maintain a list of FAQs on our [help page](http://answers.referralcandy.com/)
 
 == Changelog ==
 
+= 2.3.2 =
+* Added locale field on order meta to be sent to ReferralCandy to send emails with correct languages to customers
+* Updated additional order meta to have short keys to save space
+* Fixed translation of post-purchase popup widget on checkout
+
 = 2.3.1 =
 * Added checkbox to enable/disable marketing checkbox on checkout
 * Post-purchase popup widget uses store locale upon checkout

--- a/woocommerce-referralcandy.php
+++ b/woocommerce-referralcandy.php
@@ -6,7 +6,7 @@
  * Author: ReferralCandy
  * Author URI: http://www.referralcandy.com
  * Text Domain: woocommerce-referralcandy
- * Version: 2.3.1
+ * Version: 2.3.2
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
* Added locale field on order meta to be sent to ReferralCandy to send emails with correct languages to customers
* Updated additional order meta to have short keys to save space
* Fixed translation of post-purchase popup widget on checkout