### PR TITLE
fix: add error handling to API request in submit_purchase method of RC_Order class

### DIFF
--- a/includes/class-rc-order.php
+++ b/includes/class-rc-order.php
@@ -146,7 +146,6 @@ class RC_Order {
         if (!empty($this->secret_key) && !empty($this->api_id)) {
             $params         = $this->generate_request_body($this->generate_post_fields());
             $response       = wp_safe_remote_post($endpoint, $params);
-            $response_body  = json_decode($response['body']);
 
             if (is_wp_error($response)) {
                 return error_log(print_r($response, TRUE));

--- a/includes/class-rc-order.php
+++ b/includes/class-rc-order.php
@@ -148,6 +148,12 @@ class RC_Order {
             $response       = wp_safe_remote_post($endpoint, $params);
             $response_body  = json_decode($response['body']);
 
+            if (is_wp_error($response)) {
+                return error_log(print_r($response, TRUE));
+            }
+
+            $response_body  = json_decode($response['body']);
+
             if ($response_body->message == 'Success' && !empty($response_body->referralcorner_url)) {
                 $this->order->add_order_note('Order sent to ReferralCandy');
             }


### PR DESCRIPTION
Resolves the issue stated here: https://github.com/ReferralCandy/woocommerce-referralcandy/issues/39