### PR TITLE
fix: popup-campaign-key-tooltip error

### DIFF
--- a/includes/class-wc-referralcandy-integration.php
+++ b/includes/class-wc-referralcandy-integration.php
@@ -170,6 +170,16 @@ if (!class_exists('WC_Referralcandy_Integration')) {
 
         public function dynamic_toggle_post_purchase_popup_campaign_key_field()
         {
+            // Ensure the script and styles are only added on the WooCommerce ReferralCandy settings page.
+            if ( get_current_screen()->base !== 'woocommerce_page_wc-settings' ) {
+                return;
+            }
+            if ( ! isset($_GET['page'], $_GET['section']) ||
+                $_GET['page'] !== 'wc-settings' ||
+                $_GET['section'] !== 'referralcandy'
+            ) {
+                return;
+            }
             ?>
             <script>
                 jQuery(document).ready(function ($) {


### PR DESCRIPTION
This PR tries to fix the issue reported in [this thread](https://wordpress.org/support/topic/popup-campaign-key-tooltip-tiptip-is-not-a-function/#post-18186600) regarding a typeerror that states $(‘.popup-campaign-key-tooltip’).tipTip is not a function.

added a code snippet that was suggested by the dev in the same thread that checks if the current screen is the WooCommerce settings page and if the 'page' and 'section' query parameters are set to 'wc-settings' and 'referralcandy'